### PR TITLE
fix tags on docker hub

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# if Docker Hub builds only for test, then $CACHE_TAG is empty.
-# the $CACHE_TAG decides wich FROM is will be used.
-printf "hooks/build: CACHE_TAG: %s\n" "$CACHE_TAG"
+# if Docker Hub builds only for test, then $DOCKER_TAG is 'this'.
+# the $DOCKER_TAG decides which FROM is will be used.
+printf "hooks/build: DOCKER_TAG: %s\n" "$DOCKER_TAG"
 printf "hooks/build: IMAGE_NAME: %s\n" "$IMAGE_NAME"
 printf "hooks/build: DOCKERFILE_PATH: %s\n" "$DOCKERFILE_PATH"
 
 FROM_ARG=''
-if [[ ! -z "${CACHE_TAG}" ]]; then
-  WEB_SERVER=$(echo $CACHE_TAG | cut -f1 -d-)
+if [[ ! -z "${DOCKER_TAG}" ]] && [[ "$DOCKER_TAG" != 'this' ]]; then
+  WEB_SERVER=$(echo $DOCKER_TAG | cut -f1 -d-)
   printf "hooks/build: WEB_SERVER: %s\n" "$WEB_SERVER"
 
-  PHP_VERSION=$(echo $CACHE_TAG | cut -f2 -d-)
+  PHP_VERSION=$(echo $DOCKER_TAG | cut -f2 -d-)
   printf "hooks/build: PHP_VERSION: %s\n" "$PHP_VERSION"
 
   FROM_ARG="--build-arg FROM=webdevops/php-$WEB_SERVER-dev:$PHP_VERSION"


### PR DESCRIPTION
https://github.com/docker/docker.github.io/commit/451e897b000a91f0b426c05dae3580e55237a745

As noted in issue https://github.com/docker/docker.github.io/issues/6684 `CACHE_TAG` environment variable is actually empty in the builds, turns out the documented value is represented by a `DOCKER_TAG` variable instead.
 master (#8130)
