### PR TITLE
set APPLICATION_UID adn APPLICATION_GID to 1000 by default

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+. .env
+
+USER=${APPLICATION_UID:-1000}:${APPLICATION_GID:-1000}
+
 function startFunction {
   key="$1"
   echo "running script ${key}"
@@ -12,7 +16,7 @@ function startFunction {
         return
         ;;
      up)
-        APPLICATION_UID=$(id -u) APPLICATION_GID=$(id -g) docker-compose up -d
+        docker-compose up -d
         return
         ;;
      down)
@@ -20,11 +24,11 @@ function startFunction {
         return
         ;;
      login)
-        docker-compose exec -u $(id -u):$(id -g) web bash
+        docker-compose exec -u $USER web bash
         return
         ;;
      *)
-        APPLICATION_UID=$(id -u) APPLICATION_GID=$(id -g) docker-compose "${@:1}"
+        docker-compose "${@:1}"
         return
         ;;
   esac


### PR DESCRIPTION
Most Linux users have uid and gid 1000.
On Mac you can use dinghy, with handles all file in and out for you. so there you can simple set uid and gid to 1000 as well.
Only if you are not using dinghy and have a different uid or gid, you should set your
```
APPLICATION_UID=1000
APPLICATION_GID=1000
```
In your `.env` file