### PR TITLE
Fix special user permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The base Docker Images are [webdevops/php-apache-dev] and [webdevops/php-nginx-d
 * [TYPO3 configuration >=8](docs/typo3-configuration.md) - AdditionalConfiguration.php
 * [TYPO3 configuration <=7](docs/typo3-configuration-legacy.md) - AdditionalConfiguration.php
 * [ImageMagick or GraphicMagick](docs/magick.md) - using php module
+* [Fix special user permissions](fix-special-user-permissions.md)
 
 ## Docker compose
 
@@ -69,9 +70,9 @@ services:
 #      - PIMCORE_ENVIRONMENT=development_docker
 #      - TYPO3_CONTEXT=Development/docker
 
-#      Don't forget to connect via ./start.sh
-      - APPLICATION_UID=${APPLICATION_UID:-1000}
-      - APPLICATION_GID=${APPLICATION_GID:-1000}
+#     Fix special user permissions (only if user id not 1000)
+      - APPLICATION_UID_OVERRIDE=${APPLICATION_UID_OVERRIDE:-1000}
+      - APPLICATION_GID_OVERRIDE=${APPLICATION_GID_OVERRIDE:-1000}
 
   node:
     image: node:lts

--- a/docs/fix-special-user-permissions.md
+++ b/docs/fix-special-user-permissions.md
@@ -1,0 +1,18 @@
+# Fix special user permissions
+
+As a user with a UID other than 1000, you have permissions issues with files.
+
+The variables are automatically changed in `start.sh` for `.env`. But ultimately have to be handed over `docker-compose.yaml`.
+
+Required: APPLICATION_UID_OVERRIDE & APPLICATION_GID_OVERRIDE
+
+docker-compose.yaml:
+
+```yaml
+services:
+  web:
+    environment:
+    # Fix special user permissions
+    - APPLICATION_UID_OVERRIDE=${APPLICATION_UID_OVERRIDE:-1000}
+    - APPLICATION_GID_OVERRIDE=${APPLICATION_GID_OVERRIDE:-1000}
+```

--- a/entrypoint.d/fix-special-user-permissions.sh
+++ b/entrypoint.d/fix-special-user-permissions.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# Fix special user permissions
+APPLICATION_UID_OVERRIDE=${APPLICATION_UID_OVERRIDE:-1000}
+APPLICATION_GID_OVERRIDE=${APPLICATION_GID_OVERRIDE:-1000}
+APPLICATION_USER_OVERRIDE=${APPLICATION_USER_OVERRIDE:-app}
+APPLICATION_GROUP_OVERRIDE=${APPLICATION_USER_OVERRIDE:-app}
+
+if [ "$APPLICATION_UID_OVERRIDE" != "1000" ]; then
+    # Add group
+    groupadd -g "$APPLICATION_GID_OVERRIDE" "$APPLICATION_GROUP_OVERRIDE"
+
+    # Add user
+    useradd -u "$APPLICATION_UID_OVERRIDE" --home "/home/$APPLICATION_USER_OVERRIDE" --create-home --shell /bin/bash --no-user-group "$APPLICATION_USER_OVERRIDE"
+
+    # Assign user to group
+    usermod -g "$APPLICATION_GROUP_OVERRIDE" "$APPLICATION_USER_OVERRIDE"
+    usermod -aG sudo "$APPLICATION_USER_OVERRIDE"
+
+    # Set passwords to "dev"
+    echo "$APPLICATION_USER_OVERRIDE":"dev" | chpasswd
+
+    rsync -a /home/application/ /home/$APPLICATION_USER_OVERRIDE/
+    chown -R "$APPLICATION_USER_OVERRIDE":"$APPLICATION_GROUP_OVERRIDE" /home/$APPLICATION_USER_OVERRIDE
+fi

--- a/entrypoint.d/set-user-and-group-id.sh
+++ b/entrypoint.d/set-user-and-group-id.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-if ! id ${APPLICATION_UID} >/dev/null 2>&1; then
-    usermod -u ${APPLICATION_UID} application
-    groupmod -g ${APPLICATION_GID} application
-fi

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-. .env
-
-USER=${APPLICATION_UID:-1000}:${APPLICATION_GID:-1000}
+# Fix special user permissions
+if [ "$(id -u)" != "1000" ]; then
+    grep -q '^APPLICATION_UID_OVERRIDE=' .env && sed -i 's/^APPLICATION_UID_OVERRIDE=.*/APPLICATION_UID_OVERRIDE='$(id -u)'/' .env || echo 'APPLICATION_UID_OVERRIDE='$(id -u) >> .env
+    grep -q '^APPLICATION_GID_OVERRIDE=' .env && sed -i 's/^APPLICATION_GID_OVERRIDE=.*/APPLICATION_GID_OVERRIDE='$(id -g)'/' .env || echo 'APPLICATION_GID_OVERRIDE='$(id -g) >> .env
+fi;
 
 function startFunction {
   key="$1"
@@ -24,7 +26,7 @@ function startFunction {
         return
         ;;
      login)
-        docker-compose exec -u $USER web bash
+        docker-compose exec -u $(id -u) web bash
         return
         ;;
      *)


### PR DESCRIPTION
As a user with a UID other than 1000, you have permissions issues with files.
The variables are automatically changed in `start.sh` for `.env`. But ultimately have to be handed over `docker-compose.yaml`.

I find questionable, but it works theoretically. As a rule, you only have problems with more users.