### PR TITLE
:sparkles: changing the default timezone to Europe/Berlin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,9 @@ ENV \
     PHP_MEMORY_LIMIT="-1" \
     XHGUI_MONGO_URI="global-xhgui:27017" \
     XHGUI_PROFILING="enabled" \
-    TZ=Europe/Berlin \
-    PHP_DATE_TIMEZONE=${TZ} \
+    TZ=Europe/Berlin
 
-RUN echo ${TZ} >/etc/timezone && \
-    ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
-
-COPY entrypoint.d/* /entrypoint.d/
+COPY entrypoint.d/* /opt/docker/provision/entrypoint.d/
 
 # set apache user group to application:
 RUN if [ -f /etc/apache2/envvars ]; then sed -i 's/export APACHE_RUN_USER=www-data/export APACHE_RUN_USER=application/g' /etc/apache2/envvars ; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,6 @@ ENV \
     XHGUI_PROFILING="enabled" \
     TZ=Europe/Berlin \
     PHP_DATE_TIMEZONE=${TZ} \
-    SET_CONTAINER_TIMEZONE=true \
-    CONTAINER_TIMEZONE=${TZ}
 
 RUN echo ${TZ} >/etc/timezone && \
     ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,15 @@ ENV \
     PHP_DISPLAY_ERRORS="1" \
     PHP_MEMORY_LIMIT="-1" \
     XHGUI_MONGO_URI="global-xhgui:27017" \
-    XHGUI_PROFILING="enabled"
+    XHGUI_PROFILING="enabled" \
+    TZ=Europe/Berlin \
+    PHP_DATE_TIMEZONE=${TZ} \
+    SET_CONTAINER_TIMEZONE=true \
+    CONTAINER_TIMEZONE=${TZ}
+
+RUN echo ${TZ} >/etc/timezone && \
+    ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
 
 COPY entrypoint.d/* /entrypoint.d/
 

--- a/docs/env-variables.md
+++ b/docs/env-variables.md
@@ -19,6 +19,7 @@ These variables are for configuring the container. They can be set via the `dock
 | XHGUI_MONGO_URI      | `global-xhgui:27017` | d,php  | (php-dev) sets the report DB [see profiling](./profiling.md) [docs xhgui collector]                             |
 | XHGUI_PROFILING      | `enabled`            | d,php  | (php-dev) disables the profiling completely [docs xhgui collector]                                              |
 | COMPOSE_PROJECT_NAME | (see docs)           | d      | (docker-compose) [docs php-dev](./docker-project-name.md) [docs docker]                                         |
+| TZ                   | `Europe/Berlin`      | d      | (php-dev) [docs](https://www.php.net/manual/en/timezones.php)                                                   |
 
 
 [docs webdevops]: https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-apache-dev.html

--- a/entrypoint.d/10-set-timezone.sh
+++ b/entrypoint.d/10-set-timezone.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+if [[ -n "${PHP_DATE_TIMEZONE+x}" ]]; then
+  export TZ=${PHP_DATE_TIMEZONE}
+fi
+
+export PHP_DATE_TIMEZONE=${TZ}
+
+echo ${TZ} >/etc/timezone
+
+ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime
+
+dpkg-reconfigure -f noninteractive tzdata &> /dev/null

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,7 +27,8 @@ docker --version &&
 # composer should be installed
 composer --version &&
 # timezone should be berlin
-cat /etc/timezone && 
+cat /etc/timezone &&
 test $(cat /etc/timezone) = "Europe/Berlin" || exit 1 &&
+test $(php -r 'echo date_default_timezone_get();') = "Europe/Berlin" || exit 1 &&
 
 exit $?

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -25,6 +25,9 @@ ping -V &&
 # docker should be installed
 docker --version &&
 # composer should be installed
-composer --version
+composer --version &&
+# timezone should be berlin
+cat /etc/timezone && 
+test $(cat /etc/timezone) = "Europe/Berlin" || exit 1 &&
 
 exit $?


### PR DESCRIPTION
It's not yet entirely feature complete:
- this approach currently seems to remove the possibility to change the timezone via docker-compose