### PR TITLE
Change permissions in home directory for other id than 1000

### DIFF
--- a/entrypoint.d/00_set-user-and-group-id.sh
+++ b/entrypoint.d/00_set-user-and-group-id.sh
@@ -1,8 +1,28 @@
 #!/usr/bin/env sh
+
+updateFiles='0'
 if ! getent group ${APPLICATION_GID} >/dev/null 2>&1; then
     groupmod -g ${APPLICATION_GID} application
+    updateFiles='1'
 fi
 
-if ! id ${APPLICATION_UID} >/dev/null 2>&1; then
+if ! getent passwd ${APPLICATION_UID} >/dev/null 2>&1; then
     usermod -u ${APPLICATION_UID} application
+    updateFiles='1'
+fi
+
+if [ "${updateFiles}" == "1" ]; then
+    # Find directories and exclude mounted device
+    find /home/${APPLICATION_USER} -xdev -type d -print0 | while IFS= read -r -d '' directory; do
+        if ! mountpoint -q "${directory}"; then
+            chown "${APPLICATION_USER}":"${APPLICATION_GROUP}" ${directory}
+
+            # Find files and symlinks in current directory
+            find ${directory} -maxdepth 1 \( -type f -o -type l \) -print0 | while IFS= read -r -d '' filename; do
+                if ! mountpoint -q "${filename}"; then
+                    chown -h "${APPLICATION_USER}":"${APPLICATION_GROUP}" ${filename}
+                fi
+            done
+        fi
+    done
 fi


### PR DESCRIPTION
If the user or group ID (1001:1001) is adjusted, the home folder (/home/application) should also be adjusted.

You could do a simple chown (-R application:application /home/application), but under certain circumstances there are these problems:

* Read-only mounted causes errors
* Do you really want Docker to change your files from the main system where it should stay away from them?

This is what the script does from line 14. Find everything from a folder recursively and exclude the mounts:

* Line 16: Find all folders, but not which ones are integrated by Docker, for example and iterate it throgh.
* Line 17: Check that the path is not mounted. Most of the time `-xdev` is done, but it is more secure.
* Line 18: Chown only current iterating directory.

* Line 21: Same as line 16, but for files and symlinks in current directory.
* Line 22: Same as line 17, just for files.
* Line 23: Same as line 18, but for files and symlinks (-h)

*Note: Node service not testet.*

```text
# /home/node
drwxr-xr-x 1 node 1000 .
-rw-r--r-- 1 node 1000 .bash_logout
-rw-r--r-- 1 node 1000 .bashrc
drwxr-xr-x 3 node node .cache
-rw-r--r-- 1 node 1000 .profile
-rw-r--r-- 1 node node .yarnrc
```