### PR TITLE
Providing compatibility with old composer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,8 @@ RUN pecl install pcov && \
    echo "pcov.exclude='~vendor~'" >> /usr/local/etc/php/conf.d/docker-php-ext-pcov.ini
 
 USER application
-RUN composer global require hirak/prestissimo davidrjonas/composer-lock-diff perftools/xhgui-collector alcaeus/mongo-php-adapter && \
-    composer clear
+RUN composer1 global require hirak/prestissimo davidrjonas/composer-lock-diff perftools/xhgui-collector alcaeus/mongo-php-adapter && \
+    composer1 clear
 
 # add .git-completion.bash
 RUN curl https://raw.githubusercontent.com/git/git/v$(git --version | awk 'NF>1{print $NF}')/contrib/completion/git-completion.bash > /home/application/.git-completion.bash


### PR DESCRIPTION
https://github.com/webdevops/Dockerfile/pull/370

My suggestion would be, that we remove `prestissimo` entirely and install the other three just with composer v2.0