### PR TITLE
makes it possible to add custom prompt functions without cahnging the entrypoint

### DIFF
--- a/.additional_bashrc.sh
+++ b/.additional_bashrc.sh
@@ -38,3 +38,6 @@ if [ -v VIRTUAL_HOST ] ; then
   echo 'Frontend URLs:'
   echo $VIRTUAL_HOST | tr "," "\n" | awk '{print "  https://" $0}'
 fi
+
+# makes it possible to add custom prompt functions without cahnging the entrypoint:
+test -f ./after-bashrc_*.sh && source ./after-bashrc_*.sh || true


### PR DESCRIPTION
now you can easily add custom prompts like this:
````diff
  web:
    image: ghcr.io/pluswerk/php-dev:nginx-8.2-alpine
    working_dir: /app
    volumes:
+      - ./after-bashrc_customPrompt.sh:/home/application/after-bashrc_customPrompt.sh
````